### PR TITLE
Fix math equation numbering style.

### DIFF
--- a/src/mix.less
+++ b/src/mix.less
@@ -149,7 +149,7 @@ mark {
 }
 
 // tag
-.tag {
+.tag:not(.katex .tag) {
   background-color: var(--ls-tag-text-color);
   color: #fff !important;
   padding: 0 0.5em 0 1em;
@@ -183,7 +183,7 @@ mark {
     border-radius: 0.25em;
   }
 }
-.dark-theme .tag {
+.dark-theme .tag:not(.katex .tag) {
   color: #6b5600 !important;
 }
 


### PR DESCRIPTION
Change
![image](https://user-images.githubusercontent.com/23036788/176164483-46d53d17-2a29-4d49-8f9d-ddf971ba156f.png)
into 
![image](https://user-images.githubusercontent.com/23036788/176175324-1f700615-facf-4602-97bd-93708bceb7a6.png)
